### PR TITLE
トピック画面やマイページに移動した際にログインしていなければログイン画面に飛ばす

### DIFF
--- a/front/topicslab/src/views/Topic.vue
+++ b/front/topicslab/src/views/Topic.vue
@@ -40,6 +40,10 @@ export default {
     }
   },
   mounted () {
+    if (localStorage.getItem('authenticated') !== 'true') {
+      this.$router.push('/login')
+      return
+    }
     this.id = this.$route.params.id
     if (!this.id) {
       alert('不正なIDです。')

--- a/front/topicslab/src/views/User.vue
+++ b/front/topicslab/src/views/User.vue
@@ -29,7 +29,7 @@ export default {
   },
   mounted () {
     if (localStorage.getItem('authenticated') !== 'true') {
-      this.$router.push('login')
+      this.$router.push('/login')
       return
     }
 

--- a/front/topicslab/src/views/Userself.vue
+++ b/front/topicslab/src/views/Userself.vue
@@ -41,7 +41,7 @@ export default {
   },
   mounted () {
     if (localStorage.getItem('authenticated') !== 'true') {
-      this.$router.push('login')
+      this.$router.push('/login')
       return
     }
 


### PR DESCRIPTION
やったこと
要件14,15を終了
マイページやトピックページに移動した際にログインしていなければログインページに移動するように変更