### PR TITLE
ユーザの登録ができない問題を解決

### DIFF
--- a/api/topicsLab/app/Http/Controllers/UserController.php
+++ b/api/topicsLab/app/Http/Controllers/UserController.php
@@ -50,6 +50,7 @@ class UserController extends Controller
         $user->name = $request->name;
         $user->email = $request->email;
         $user->password = Hash::make($request->password);
+        $user->intro = "";
         $user->save();
         return $user;
     }


### PR DESCRIPTION
userのintroがnullで登録できていなかったので、初回に""で登録するようにしました。
時間があったらmigrationファイル作って
introをdefalut nullにした方がいいかもしれないです。